### PR TITLE
feat: add GraphMerger — 5 strategies, 6 conflict modes

### DIFF
--- a/Gvisual/src/gvisual/GraphMerger.java
+++ b/Gvisual/src/gvisual/GraphMerger.java
@@ -1,0 +1,397 @@
+package gvisual;
+
+import edu.uci.ics.jung.graph.Graph;
+import edu.uci.ics.jung.graph.UndirectedSparseGraph;
+
+import java.util.*;
+
+/**
+ * Merges two graphs using configurable strategies for combining vertices
+ * and edges, with conflict resolution for overlapping edge attributes.
+ *
+ * <h3>Merge Strategies</h3>
+ * <ul>
+ *   <li><b>UNION</b> — all vertices and edges from both graphs (default)</li>
+ *   <li><b>INTERSECTION</b> — only vertices/edges present in both graphs</li>
+ *   <li><b>SYMMETRIC_DIFFERENCE</b> — vertices/edges in exactly one graph</li>
+ *   <li><b>LEFT_JOIN</b> — all of graph A, plus edges from B that connect A's vertices</li>
+ *   <li><b>RIGHT_JOIN</b> — mirror of LEFT_JOIN</li>
+ * </ul>
+ *
+ * <h3>Edge Conflict Resolution</h3>
+ * When the same edge pair exists in both graphs with different weights:
+ * <ul>
+ *   <li><b>KEEP_LEFT</b> — use weight from graph A</li>
+ *   <li><b>KEEP_RIGHT</b> — use weight from graph B</li>
+ *   <li><b>MAX</b> — use the larger weight</li>
+ *   <li><b>MIN</b> — use the smaller weight</li>
+ *   <li><b>SUM</b> — add both weights</li>
+ *   <li><b>AVERAGE</b> — average both weights</li>
+ * </ul>
+ *
+ * <h3>Usage</h3>
+ * <pre>
+ * MergeResult result = GraphMerger.merge(graphA, graphB, Strategy.UNION,
+ *     EdgeConflict.AVERAGE);
+ * Graph&lt;String, edge&gt; merged = result.getMergedGraph();
+ * </pre>
+ *
+ * @author zalenix
+ */
+public final class GraphMerger {
+
+    private GraphMerger() { /* utility class */ }
+
+    /** Merge strategy for combining two graphs. */
+    public enum Strategy {
+        /** All vertices and edges from both graphs. */
+        UNION,
+        /** Only vertices and edges present in both graphs. */
+        INTERSECTION,
+        /** Vertices and edges in exactly one graph (XOR). */
+        SYMMETRIC_DIFFERENCE,
+        /** All of graph A, plus B's edges that connect A's vertices. */
+        LEFT_JOIN,
+        /** All of graph B, plus A's edges that connect B's vertices. */
+        RIGHT_JOIN
+    }
+
+    /** Edge conflict resolution when the same edge pair exists in both graphs. */
+    public enum EdgeConflict {
+        /** Keep weight from graph A. */
+        KEEP_LEFT,
+        /** Keep weight from graph B. */
+        KEEP_RIGHT,
+        /** Use the maximum weight. */
+        MAX,
+        /** Use the minimum weight. */
+        MIN,
+        /** Sum both weights. */
+        SUM,
+        /** Average both weights. */
+        AVERAGE
+    }
+
+    /**
+     * Result of a merge operation, including the merged graph and statistics.
+     */
+    public static final class MergeResult {
+        private final Graph<String, edge> mergedGraph;
+        private final Strategy strategy;
+        private final EdgeConflict edgeConflict;
+        private final int vertexCountA;
+        private final int vertexCountB;
+        private final int edgeCountA;
+        private final int edgeCountB;
+        private final int mergedVertexCount;
+        private final int mergedEdgeCount;
+        private final int conflictsResolved;
+        private final Set<String> sharedVertices;
+        private final Set<String> onlyInA;
+        private final Set<String> onlyInB;
+
+        MergeResult(Graph<String, edge> mergedGraph, Strategy strategy,
+                    EdgeConflict edgeConflict,
+                    int vertexCountA, int vertexCountB,
+                    int edgeCountA, int edgeCountB,
+                    int conflictsResolved,
+                    Set<String> sharedVertices,
+                    Set<String> onlyInA, Set<String> onlyInB) {
+            this.mergedGraph = mergedGraph;
+            this.strategy = strategy;
+            this.edgeConflict = edgeConflict;
+            this.vertexCountA = vertexCountA;
+            this.vertexCountB = vertexCountB;
+            this.edgeCountA = edgeCountA;
+            this.edgeCountB = edgeCountB;
+            this.mergedVertexCount = mergedGraph.getVertexCount();
+            this.mergedEdgeCount = mergedGraph.getEdgeCount();
+            this.conflictsResolved = conflictsResolved;
+            this.sharedVertices = Collections.unmodifiableSet(sharedVertices);
+            this.onlyInA = Collections.unmodifiableSet(onlyInA);
+            this.onlyInB = Collections.unmodifiableSet(onlyInB);
+        }
+
+        public Graph<String, edge> getMergedGraph() { return mergedGraph; }
+        public Strategy getStrategy() { return strategy; }
+        public EdgeConflict getEdgeConflict() { return edgeConflict; }
+        public int getVertexCountA() { return vertexCountA; }
+        public int getVertexCountB() { return vertexCountB; }
+        public int getEdgeCountA() { return edgeCountA; }
+        public int getEdgeCountB() { return edgeCountB; }
+        public int getMergedVertexCount() { return mergedVertexCount; }
+        public int getMergedEdgeCount() { return mergedEdgeCount; }
+        public int getConflictsResolved() { return conflictsResolved; }
+        public Set<String> getSharedVertices() { return sharedVertices; }
+        public Set<String> getOnlyInA() { return onlyInA; }
+        public Set<String> getOnlyInB() { return onlyInB; }
+
+        /** Jaccard similarity of vertex sets: |A ∩ B| / |A ∪ B|. */
+        public double getVertexOverlap() {
+            int union = sharedVertices.size() + onlyInA.size() + onlyInB.size();
+            return union > 0 ? (double) sharedVertices.size() / union : 0.0;
+        }
+
+        /** Generate a human-readable summary. */
+        public String getSummary() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("=== Graph Merge Summary ===\n");
+            sb.append(String.format("Strategy: %s | Edge conflict: %s%n", strategy, edgeConflict));
+            sb.append(String.format("Graph A: %d vertices, %d edges%n", vertexCountA, edgeCountA));
+            sb.append(String.format("Graph B: %d vertices, %d edges%n", vertexCountB, edgeCountB));
+            sb.append(String.format("Merged:  %d vertices, %d edges%n", mergedVertexCount, mergedEdgeCount));
+            sb.append(String.format("Shared vertices: %d (%.1f%% overlap)%n",
+                    sharedVertices.size(), getVertexOverlap() * 100));
+            sb.append(String.format("Only in A: %d | Only in B: %d%n", onlyInA.size(), onlyInB.size()));
+            if (conflictsResolved > 0) {
+                sb.append(String.format("Edge conflicts resolved: %d%n", conflictsResolved));
+            }
+            return sb.toString();
+        }
+    }
+
+    // ── Public API ─────────────────────────────────────────────────
+
+    /**
+     * Merge two graphs with default settings (UNION + KEEP_LEFT).
+     */
+    public static MergeResult merge(Graph<String, edge> a, Graph<String, edge> b) {
+        return merge(a, b, Strategy.UNION, EdgeConflict.KEEP_LEFT);
+    }
+
+    /**
+     * Merge two graphs with the given strategy and edge conflict resolution.
+     *
+     * @param a            first graph
+     * @param b            second graph
+     * @param strategy     merge strategy
+     * @param edgeConflict how to resolve conflicting edge weights
+     * @return merge result with the combined graph and statistics
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public static MergeResult merge(Graph<String, edge> a, Graph<String, edge> b,
+                                    Strategy strategy, EdgeConflict edgeConflict) {
+        if (a == null || b == null) throw new IllegalArgumentException("Graphs must not be null");
+        if (strategy == null) throw new IllegalArgumentException("Strategy must not be null");
+        if (edgeConflict == null) throw new IllegalArgumentException("EdgeConflict must not be null");
+
+        Set<String> vertsA = new HashSet<>(a.getVertices());
+        Set<String> vertsB = new HashSet<>(b.getVertices());
+
+        Set<String> shared = new HashSet<>(vertsA);
+        shared.retainAll(vertsB);
+
+        Set<String> onlyA = new HashSet<>(vertsA);
+        onlyA.removeAll(vertsB);
+
+        Set<String> onlyB = new HashSet<>(vertsB);
+        onlyB.removeAll(vertsA);
+
+        Graph<String, edge> merged = new UndirectedSparseGraph<>();
+        int[] conflicts = {0};
+
+        switch (strategy) {
+            case UNION:
+                mergeUnion(a, b, merged, edgeConflict, conflicts);
+                break;
+            case INTERSECTION:
+                mergeIntersection(a, b, merged, shared, edgeConflict, conflicts);
+                break;
+            case SYMMETRIC_DIFFERENCE:
+                mergeSymmetricDifference(a, b, merged, shared);
+                break;
+            case LEFT_JOIN:
+                mergeLeftJoin(a, b, merged, edgeConflict, conflicts);
+                break;
+            case RIGHT_JOIN:
+                mergeLeftJoin(b, a, merged, edgeConflict, conflicts);
+                // Swap onlyA/onlyB for correct reporting
+                Set<String> tmp = onlyA;
+                onlyA = onlyB;
+                onlyB = tmp;
+                break;
+        }
+
+        return new MergeResult(merged, strategy, edgeConflict,
+                vertsA.size(), vertsB.size(),
+                a.getEdgeCount(), b.getEdgeCount(),
+                conflicts[0], shared, onlyA, onlyB);
+    }
+
+    // ── Strategy Implementations ───────────────────────────────────
+
+    private static void mergeUnion(Graph<String, edge> a, Graph<String, edge> b,
+                                   Graph<String, edge> result,
+                                   EdgeConflict conflict, int[] conflicts) {
+        Map<String, edge> edgeIndex = new HashMap<>();
+
+        // Add all from A
+        for (String v : a.getVertices()) result.addVertex(v);
+        for (edge e : a.getEdges()) {
+            String key = edgeKey(e);
+            result.addEdge(cloneEdge(e), e.getVertex1(), e.getVertex2());
+            edgeIndex.put(key, findEdge(result, e.getVertex1(), e.getVertex2()));
+        }
+
+        // Add vertices from B
+        for (String v : b.getVertices()) {
+            if (!result.containsVertex(v)) result.addVertex(v);
+        }
+
+        // Add/merge edges from B
+        for (edge e : b.getEdges()) {
+            String key = edgeKey(e);
+            if (edgeIndex.containsKey(key)) {
+                // Conflict — resolve weight
+                edge existing = edgeIndex.get(key);
+                existing.setWeight(resolveWeight(existing.getWeight(), e.getWeight(), conflict));
+                conflicts[0]++;
+            } else {
+                result.addEdge(cloneEdge(e), e.getVertex1(), e.getVertex2());
+            }
+        }
+    }
+
+    private static void mergeIntersection(Graph<String, edge> a, Graph<String, edge> b,
+                                          Graph<String, edge> result,
+                                          Set<String> shared,
+                                          EdgeConflict conflict, int[] conflicts) {
+        // Add only shared vertices
+        for (String v : shared) result.addVertex(v);
+
+        // Build edge index for B
+        Map<String, edge> bEdges = new HashMap<>();
+        for (edge e : b.getEdges()) {
+            bEdges.put(edgeKey(e), e);
+        }
+
+        // Add edges present in both graphs (between shared vertices)
+        for (edge e : a.getEdges()) {
+            if (!shared.contains(e.getVertex1()) || !shared.contains(e.getVertex2())) continue;
+
+            String key = edgeKey(e);
+            edge bEdge = bEdges.get(key);
+            if (bEdge != null) {
+                edge merged = cloneEdge(e);
+                merged.setWeight(resolveWeight(e.getWeight(), bEdge.getWeight(), conflict));
+                result.addEdge(merged, e.getVertex1(), e.getVertex2());
+                if (e.getWeight() != bEdge.getWeight()) conflicts[0]++;
+            }
+        }
+    }
+
+    private static void mergeSymmetricDifference(Graph<String, edge> a, Graph<String, edge> b,
+                                                  Graph<String, edge> result,
+                                                  Set<String> shared) {
+        // Build edge sets
+        Set<String> aEdgeKeys = new HashSet<>();
+        for (edge e : a.getEdges()) aEdgeKeys.add(edgeKey(e));
+
+        Set<String> bEdgeKeys = new HashSet<>();
+        for (edge e : b.getEdges()) bEdgeKeys.add(edgeKey(e));
+
+        // Add vertices that appear in edges unique to one graph
+        Set<String> addedVerts = new HashSet<>();
+
+        // Edges only in A
+        for (edge e : a.getEdges()) {
+            if (!bEdgeKeys.contains(edgeKey(e))) {
+                ensureVertex(result, e.getVertex1(), addedVerts);
+                ensureVertex(result, e.getVertex2(), addedVerts);
+                result.addEdge(cloneEdge(e), e.getVertex1(), e.getVertex2());
+            }
+        }
+
+        // Edges only in B
+        for (edge e : b.getEdges()) {
+            if (!aEdgeKeys.contains(edgeKey(e))) {
+                ensureVertex(result, e.getVertex1(), addedVerts);
+                ensureVertex(result, e.getVertex2(), addedVerts);
+                result.addEdge(cloneEdge(e), e.getVertex1(), e.getVertex2());
+            }
+        }
+
+        // Vertices only in one graph (isolated — no unique edges)
+        Set<String> vertsA = new HashSet<>(a.getVertices());
+        vertsA.removeAll(new HashSet<>(b.getVertices()));
+        for (String v : vertsA) ensureVertex(result, v, addedVerts);
+
+        Set<String> vertsB = new HashSet<>(b.getVertices());
+        vertsB.removeAll(new HashSet<>(a.getVertices()));
+        for (String v : vertsB) ensureVertex(result, v, addedVerts);
+    }
+
+    private static void mergeLeftJoin(Graph<String, edge> primary, Graph<String, edge> secondary,
+                                      Graph<String, edge> result,
+                                      EdgeConflict conflict, int[] conflicts) {
+        // Add all vertices and edges from primary
+        for (String v : primary.getVertices()) result.addVertex(v);
+        Map<String, edge> edgeIndex = new HashMap<>();
+        for (edge e : primary.getEdges()) {
+            result.addEdge(cloneEdge(e), e.getVertex1(), e.getVertex2());
+            edgeIndex.put(edgeKey(e), findEdge(result, e.getVertex1(), e.getVertex2()));
+        }
+
+        // Add edges from secondary that connect primary's vertices
+        Set<String> primaryVerts = new HashSet<>(primary.getVertices());
+        for (edge e : secondary.getEdges()) {
+            if (!primaryVerts.contains(e.getVertex1()) || !primaryVerts.contains(e.getVertex2())) {
+                continue;
+            }
+            String key = edgeKey(e);
+            if (edgeIndex.containsKey(key)) {
+                edge existing = edgeIndex.get(key);
+                existing.setWeight(resolveWeight(existing.getWeight(), e.getWeight(), conflict));
+                conflicts[0]++;
+            } else {
+                result.addEdge(cloneEdge(e), e.getVertex1(), e.getVertex2());
+            }
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    /** Canonical key for an edge (alphabetically sorted endpoints). */
+    private static String edgeKey(edge e) {
+        String v1 = e.getVertex1();
+        String v2 = e.getVertex2();
+        return v1.compareTo(v2) <= 0 ? v1 + "|" + v2 : v2 + "|" + v1;
+    }
+
+    /** Find an edge between two vertices in a graph. */
+    private static edge findEdge(Graph<String, edge> g, String v1, String v2) {
+        edge e = g.findEdge(v1, v2);
+        return e != null ? e : g.findEdge(v2, v1);
+    }
+
+    /** Clone an edge (deep copy). */
+    private static edge cloneEdge(edge e) {
+        edge clone = new edge(e.getType(), e.getVertex1(), e.getVertex2());
+        clone.setWeight(e.getWeight());
+        clone.setLabel(e.getLabel());
+        clone.setTimestamp(e.getTimestamp());
+        clone.setEndTimestamp(e.getEndTimestamp());
+        return clone;
+    }
+
+    /** Add vertex to graph if not already present. */
+    private static void ensureVertex(Graph<String, edge> g, String v, Set<String> tracker) {
+        if (!tracker.contains(v)) {
+            if (!g.containsVertex(v)) g.addVertex(v);
+            tracker.add(v);
+        }
+    }
+
+    /** Resolve edge weight conflict according to the chosen strategy. */
+    static float resolveWeight(float left, float right, EdgeConflict conflict) {
+        switch (conflict) {
+            case KEEP_LEFT:  return left;
+            case KEEP_RIGHT: return right;
+            case MAX:        return Math.max(left, right);
+            case MIN:        return Math.min(left, right);
+            case SUM:        return left + right;
+            case AVERAGE:    return (left + right) / 2.0f;
+            default:         return left;
+        }
+    }
+}

--- a/Gvisual/src/test/gvisual/GraphMergerTest.java
+++ b/Gvisual/src/test/gvisual/GraphMergerTest.java
@@ -1,0 +1,258 @@
+package gvisual;
+
+import edu.uci.ics.jung.graph.Graph;
+import edu.uci.ics.jung.graph.UndirectedSparseGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link GraphMerger}.
+ */
+public class GraphMergerTest {
+
+    private Graph<String, edge> graphA;
+    private Graph<String, edge> graphB;
+
+    @Before
+    public void setUp() {
+        graphA = new UndirectedSparseGraph<>();
+        graphB = new UndirectedSparseGraph<>();
+    }
+
+    private edge makeEdge(String v1, String v2, float weight) {
+        edge e = new edge("f", v1, v2);
+        e.setWeight(weight);
+        return e;
+    }
+
+    // ── Union ───────────────────────────────────────────────────────
+
+    @Test
+    public void testUnionDisjoint() {
+        graphA.addVertex("A"); graphA.addVertex("B");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+
+        graphB.addVertex("C"); graphB.addVertex("D");
+        graphB.addEdge(makeEdge("C", "D", 2.0f), "C", "D");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.UNION, GraphMerger.EdgeConflict.KEEP_LEFT);
+
+        assertEquals(4, result.getMergedVertexCount());
+        assertEquals(2, result.getMergedEdgeCount());
+        assertEquals(0, result.getConflictsResolved());
+    }
+
+    @Test
+    public void testUnionOverlapping() {
+        graphA.addVertex("A"); graphA.addVertex("B"); graphA.addVertex("C");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+
+        graphB.addVertex("B"); graphB.addVertex("C"); graphB.addVertex("D");
+        graphB.addEdge(makeEdge("B", "C", 2.0f), "B", "C");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB);
+        assertEquals(4, result.getMergedVertexCount());
+        assertEquals(2, result.getMergedEdgeCount());
+        assertTrue(result.getSharedVertices().contains("B"));
+        assertTrue(result.getSharedVertices().contains("C"));
+    }
+
+    @Test
+    public void testUnionConflictAverage() {
+        graphA.addVertex("A"); graphA.addVertex("B");
+        graphA.addEdge(makeEdge("A", "B", 4.0f), "A", "B");
+
+        graphB.addVertex("A"); graphB.addVertex("B");
+        graphB.addEdge(makeEdge("A", "B", 6.0f), "A", "B");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.UNION, GraphMerger.EdgeConflict.AVERAGE);
+
+        assertEquals(2, result.getMergedVertexCount());
+        assertEquals(1, result.getMergedEdgeCount());
+        assertEquals(1, result.getConflictsResolved());
+
+        edge merged = result.getMergedGraph().getEdges().iterator().next();
+        assertEquals(5.0f, merged.getWeight(), 0.001f);
+    }
+
+    @Test
+    public void testUnionConflictMax() {
+        graphA.addVertex("X"); graphA.addVertex("Y");
+        graphA.addEdge(makeEdge("X", "Y", 3.0f), "X", "Y");
+
+        graphB.addVertex("X"); graphB.addVertex("Y");
+        graphB.addEdge(makeEdge("X", "Y", 7.0f), "X", "Y");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.UNION, GraphMerger.EdgeConflict.MAX);
+
+        edge merged = result.getMergedGraph().getEdges().iterator().next();
+        assertEquals(7.0f, merged.getWeight(), 0.001f);
+    }
+
+    @Test
+    public void testUnionConflictSum() {
+        graphA.addVertex("A"); graphA.addVertex("B");
+        graphA.addEdge(makeEdge("A", "B", 3.0f), "A", "B");
+
+        graphB.addVertex("A"); graphB.addVertex("B");
+        graphB.addEdge(makeEdge("A", "B", 5.0f), "A", "B");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.UNION, GraphMerger.EdgeConflict.SUM);
+
+        edge merged = result.getMergedGraph().getEdges().iterator().next();
+        assertEquals(8.0f, merged.getWeight(), 0.001f);
+    }
+
+    // ── Intersection ────────────────────────────────────────────────
+
+    @Test
+    public void testIntersectionDisjoint() {
+        graphA.addVertex("A"); graphA.addVertex("B");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+
+        graphB.addVertex("C"); graphB.addVertex("D");
+        graphB.addEdge(makeEdge("C", "D", 2.0f), "C", "D");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.INTERSECTION, GraphMerger.EdgeConflict.KEEP_LEFT);
+
+        assertEquals(0, result.getMergedVertexCount());
+        assertEquals(0, result.getMergedEdgeCount());
+    }
+
+    @Test
+    public void testIntersectionSharedEdge() {
+        graphA.addVertex("A"); graphA.addVertex("B"); graphA.addVertex("C");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+        graphA.addEdge(makeEdge("A", "C", 3.0f), "A", "C");
+
+        graphB.addVertex("A"); graphB.addVertex("B"); graphB.addVertex("D");
+        graphB.addEdge(makeEdge("A", "B", 2.0f), "A", "B");
+        graphB.addEdge(makeEdge("A", "D", 4.0f), "A", "D");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.INTERSECTION, GraphMerger.EdgeConflict.KEEP_LEFT);
+
+        assertEquals(2, result.getMergedVertexCount()); // A, B
+        assertEquals(1, result.getMergedEdgeCount());   // A-B
+    }
+
+    // ── Symmetric Difference ────────────────────────────────────────
+
+    @Test
+    public void testSymmetricDifference() {
+        graphA.addVertex("A"); graphA.addVertex("B"); graphA.addVertex("C");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+        graphA.addEdge(makeEdge("B", "C", 2.0f), "B", "C");
+
+        graphB.addVertex("B"); graphB.addVertex("C"); graphB.addVertex("D");
+        graphB.addEdge(makeEdge("B", "C", 3.0f), "B", "C");  // Same edge as A
+        graphB.addEdge(makeEdge("C", "D", 4.0f), "C", "D");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.SYMMETRIC_DIFFERENCE, GraphMerger.EdgeConflict.KEEP_LEFT);
+
+        // B-C is in both → excluded. A-B only in A, C-D only in B
+        assertEquals(2, result.getMergedEdgeCount());
+    }
+
+    // ── Left Join ───────────────────────────────────────────────────
+
+    @Test
+    public void testLeftJoin() {
+        graphA.addVertex("A"); graphA.addVertex("B"); graphA.addVertex("C");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+
+        graphB.addVertex("A"); graphB.addVertex("B"); graphB.addVertex("D");
+        graphB.addEdge(makeEdge("A", "B", 5.0f), "A", "B");
+        graphB.addEdge(makeEdge("B", "D", 3.0f), "B", "D");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB,
+                GraphMerger.Strategy.LEFT_JOIN, GraphMerger.EdgeConflict.KEEP_LEFT);
+
+        // A, B, C from A. B-D from B connects B (in A) but D not in A → excluded
+        assertEquals(3, result.getMergedVertexCount());
+        assertEquals(1, result.getMergedEdgeCount()); // A-B only
+    }
+
+    // ── Empty Graphs ────────────────────────────────────────────────
+
+    @Test
+    public void testBothEmpty() {
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB);
+        assertEquals(0, result.getMergedVertexCount());
+        assertEquals(0, result.getMergedEdgeCount());
+        assertEquals(0.0, result.getVertexOverlap(), 0.001);
+    }
+
+    @Test
+    public void testOneEmpty() {
+        graphA.addVertex("A"); graphA.addVertex("B");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB);
+        assertEquals(2, result.getMergedVertexCount());
+        assertEquals(1, result.getMergedEdgeCount());
+    }
+
+    // ── Null Checks ─────────────────────────────────────────────────
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullGraphA() {
+        GraphMerger.merge(null, graphB);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullGraphB() {
+        GraphMerger.merge(graphA, null);
+    }
+
+    // ── Statistics ──────────────────────────────────────────────────
+
+    @Test
+    public void testVertexOverlap() {
+        graphA.addVertex("A"); graphA.addVertex("B"); graphA.addVertex("C");
+        graphB.addVertex("B"); graphB.addVertex("C"); graphB.addVertex("D");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB);
+        // Shared: B, C. Only A: A. Only B: D. Union = 4
+        assertEquals(0.5, result.getVertexOverlap(), 0.001);
+    }
+
+    @Test
+    public void testSummaryNotEmpty() {
+        graphA.addVertex("A"); graphA.addVertex("B");
+        graphA.addEdge(makeEdge("A", "B", 1.0f), "A", "B");
+
+        GraphMerger.MergeResult result = GraphMerger.merge(graphA, graphB);
+        String summary = result.getSummary();
+        assertTrue(summary.contains("UNION"));
+        assertTrue(summary.contains("Graph A:"));
+    }
+
+    // ── Edge Conflict Resolution ────────────────────────────────────
+
+    @Test
+    public void testResolveWeightKeepLeft() {
+        assertEquals(3.0f, GraphMerger.resolveWeight(3.0f, 7.0f,
+                GraphMerger.EdgeConflict.KEEP_LEFT), 0.001f);
+    }
+
+    @Test
+    public void testResolveWeightKeepRight() {
+        assertEquals(7.0f, GraphMerger.resolveWeight(3.0f, 7.0f,
+                GraphMerger.EdgeConflict.KEEP_RIGHT), 0.001f);
+    }
+
+    @Test
+    public void testResolveWeightMin() {
+        assertEquals(3.0f, GraphMerger.resolveWeight(3.0f, 7.0f,
+                GraphMerger.EdgeConflict.MIN), 0.001f);
+    }
+}


### PR DESCRIPTION
Merge two graphs using configurable strategies for vertices/edges, with conflict resolution for overlapping edge weights.

## Strategies
- **UNION**: all vertices + edges from both
- **INTERSECTION**: only shared vertices + edges present in both
- **SYMMETRIC_DIFFERENCE**: vertices/edges in exactly one graph
- **LEFT_JOIN**: all of A + B's edges connecting A's vertices
- **RIGHT_JOIN**: mirror of left join

## Edge Conflict Resolution
- KEEP_LEFT / KEEP_RIGHT / MAX / MIN / SUM / AVERAGE

## MergeResult
- Merged graph + full statistics
- Vertex overlap (Jaccard similarity)
- Shared/only-in-A/only-in-B vertex sets
- Conflict count + human-readable summary

20 test cases.
