### PR TITLE
security: path-traversal validation for file exporters (CWE-22)

### DIFF
--- a/Gvisual/src/gvisual/CsvReportExporter.java
+++ b/Gvisual/src/gvisual/CsvReportExporter.java
@@ -70,6 +70,7 @@ public class CsvReportExporter {
      * @throws IOException if writing fails
      */
     public void export(File file) throws IOException {
+        ExportUtils.validateOutputPath(file);
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
             writer.write(exportToString());
         }

--- a/Gvisual/src/gvisual/ExportUtils.java
+++ b/Gvisual/src/gvisual/ExportUtils.java
@@ -1,0 +1,48 @@
+package gvisual;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Shared security utilities for file exporters.
+ *
+ * <p>Provides output-path validation to prevent directory-traversal
+ * attacks (CWE-22) when exporting graphs, reports, or HTML files.
+ *
+ * @author zalenix
+ */
+public final class ExportUtils {
+
+    private ExportUtils() { /* utility class */ }
+
+    /**
+     * Validates that an output file path is safe to write to.
+     *
+     * <p>The resolved (canonical) path must reside within the current
+     * working directory or within the system temporary directory.
+     * Paths that escape these directories via {@code ..} or symlinks
+     * are rejected with a {@link SecurityException}.
+     *
+     * @param file the proposed output file
+     * @throws SecurityException if the path escapes allowed directories
+     * @throws IOException if canonicalization fails
+     */
+    public static void validateOutputPath(File file) throws IOException {
+        File canonical = file.getCanonicalFile();
+        File cwd = new File(".").getCanonicalFile();
+        File tmpDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
+
+        if (canonical.toPath().startsWith(cwd.toPath())) {
+            return; // within working directory — allowed
+        }
+        if (canonical.toPath().startsWith(tmpDir.toPath())) {
+            return; // within temp directory — allowed
+        }
+
+        throw new SecurityException(
+            "Export path must be within the working directory or temp directory. "
+            + "Resolved path: " + canonical.getAbsolutePath()
+            + " (CWD: " + cwd.getAbsolutePath()
+            + ", TMP: " + tmpDir.getAbsolutePath() + ")");
+    }
+}

--- a/Gvisual/src/gvisual/GraphMLExporter.java
+++ b/Gvisual/src/gvisual/GraphMLExporter.java
@@ -96,6 +96,7 @@ public class GraphMLExporter {
      * @throws IOException if writing fails
      */
     public void export(File file) throws IOException {
+        ExportUtils.validateOutputPath(file);
         try (Writer writer = new BufferedWriter(
                 new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
             writer.write(exportToString());

--- a/Gvisual/src/gvisual/InteractiveHtmlExporter.java
+++ b/Gvisual/src/gvisual/InteractiveHtmlExporter.java
@@ -71,6 +71,7 @@ public class InteractiveHtmlExporter {
      * @throws IOException if writing fails
      */
     public void export(File file) throws IOException {
+        ExportUtils.validateOutputPath(file);
         try (Writer w = new BufferedWriter(new OutputStreamWriter(
                 new FileOutputStream(file), StandardCharsets.UTF_8))) {
             w.write(exportToString());
@@ -430,7 +431,7 @@ public class InteractiveHtmlExporter {
 
     private static String escHtml(String s) {
         if (s == null) return "";
-        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;");
     }
 
     private static String escJs(String s) {

--- a/Gvisual/test/gvisual/ExportUtilsTest.java
+++ b/Gvisual/test/gvisual/ExportUtilsTest.java
@@ -1,0 +1,60 @@
+package gvisual;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+/**
+ * Tests for {@link ExportUtils} path validation (CWE-22 prevention).
+ */
+public class ExportUtilsTest {
+
+    @Test
+    public void allowsFileInWorkingDirectory() throws Exception {
+        File safe = new File("output.txt");
+        ExportUtils.validateOutputPath(safe);
+        // No exception — passes
+    }
+
+    @Test
+    public void allowsFileInSubdirectory() throws Exception {
+        File safe = new File("subdir/output.txt");
+        ExportUtils.validateOutputPath(safe);
+    }
+
+    @Test
+    public void allowsFileInTempDirectory() throws Exception {
+        File tmpFile = File.createTempFile("export_test_", ".txt");
+        tmpFile.deleteOnExit();
+        ExportUtils.validateOutputPath(tmpFile);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsParentDirectoryTraversal() throws Exception {
+        File traversal = new File("../../etc/passwd");
+        ExportUtils.validateOutputPath(traversal);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsAbsolutePathOutsideAllowed() throws Exception {
+        // Use a path that's definitely outside CWD and temp
+        String root = System.getProperty("os.name").toLowerCase().contains("win")
+            ? "C:\\Windows\\System32\\evil.txt"
+            : "/etc/evil.txt";
+        File outside = new File(root);
+        ExportUtils.validateOutputPath(outside);
+    }
+
+    @Test
+    public void handlesCurrentDirectoryRef() throws Exception {
+        File dotRef = new File("./output.txt");
+        ExportUtils.validateOutputPath(dotRef);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsDeepTraversal() throws Exception {
+        File deep = new File("a/b/../../../../outside.txt");
+        ExportUtils.validateOutputPath(deep);
+    }
+}


### PR DESCRIPTION
All three file exporters accepted arbitrary File paths without validation, enabling directory-traversal attacks (CWE-22).

## Changes
- **ExportUtils.validateOutputPath()** — new shared utility that rejects paths escaping the working directory or temp directory after canonicalization
- **CsvReportExporter.export()** — now validates path before writing
- **GraphMLExporter.export()** — now validates path before writing  
- **InteractiveHtmlExporter.export()** — now validates path before writing
- **InteractiveHtmlExporter.escHtml()** — added missing single-quote escape (CWE-79)
- **ExportUtilsTest** — 7 tests: CWD allowed, subdirectory, temp dir, parent traversal rejected, absolute path rejected, dot-ref, deep traversal rejected
