### PR TITLE
fix: correct totalWeight for zero-weight edges in Dijkstra and int overflow in density

### DIFF
--- a/Gvisual/src/gvisual/GraphStats.java
+++ b/Gvisual/src/gvisual/GraphStats.java
@@ -90,7 +90,7 @@ public class GraphStats {
         int v = getNodeCount();
         int e = getVisibleEdgeCount();
         if (v < 2) return 0.0;
-        return (2.0 * e) / (v * (v - 1));
+        return (2.0 * e) / ((long) v * (v - 1));
     }
 
     /**

--- a/Gvisual/src/gvisual/ShortestPathFinder.java
+++ b/Gvisual/src/gvisual/ShortestPathFinder.java
@@ -192,7 +192,7 @@ public class ShortestPathFinder {
             visited.add(current);
 
             if (current.equals(target)) {
-                return buildPath(source, target, predecessor, predecessorEdge);
+                return buildPath(source, target, predecessor, predecessorEdge, true);
             }
 
             for (edge e : graph.getIncidentEdges(current)) {
@@ -314,6 +314,20 @@ public class ShortestPathFinder {
     private PathResult buildPath(String source, String target,
                                  Map<String, String> predecessor,
                                  Map<String, edge> predecessorEdge) {
+        return buildPath(source, target, predecessor, predecessorEdge, false);
+    }
+
+    /**
+     * Builds a PathResult by tracing predecessors from target back to source.
+     *
+     * @param normalizeZeroWeights if true, treat zero-weight edges as weight 1.0
+     *                             (must match the convention used by the caller,
+     *                             e.g. Dijkstra normalizes zero weights to 1.0)
+     */
+    private PathResult buildPath(String source, String target,
+                                 Map<String, String> predecessor,
+                                 Map<String, edge> predecessorEdge,
+                                 boolean normalizeZeroWeights) {
         List<String> vertices = new ArrayList<String>();
         List<edge> edges = new ArrayList<edge>();
         double totalWeight = 0;
@@ -324,7 +338,9 @@ public class ShortestPathFinder {
             edge e = predecessorEdge.get(current);
             if (e != null) {
                 edges.add(e);
-                totalWeight += e.getWeight();
+                double w = e.getWeight();
+                if (normalizeZeroWeights && w == 0) w = 1.0;
+                totalWeight += w;
             }
             current = predecessor.get(current);
         }


### PR DESCRIPTION
## Bug Fixes

### 1. ShortestPathFinder: incorrect totalWeight for zero-weight edges

**Problem:** \indShortestByWeight()\ normalizes zero-weight edges to 1.0 during Dijkstra traversal, but \uildPath()\ sums raw \.getWeight()\ values. This means \PathResult.getTotalWeight()\ returns 0 for paths through zero-weight edges when the actual traversal cost was positive.

**Fix:** Added a \
ormalizeZeroWeights\ parameter to \uildPath()\ so the weight normalization is consistent between traversal and result construction. BFS paths (hop-based) continue using raw weights since they don't normalize.

### 2. GraphStats: integer overflow in getDensity()

**Problem:** \ * (v - 1)\ is computed as \int * int\, which silently overflows for graphs with more than ~46K nodes (int max ~2.1B), producing incorrect density values.

**Fix:** Cast to \long\ before multiplication: \(long) v * (v - 1)\.