### PR TITLE
fix: CWE-190 integer overflow in n*(n-1)/2 pair count

### DIFF
--- a/Gvisual/src/gvisual/GraphClusterQualityAnalyzer.java
+++ b/Gvisual/src/gvisual/GraphClusterQualityAnalyzer.java
@@ -333,7 +333,7 @@ public class GraphClusterQualityAnalyzer {
 
             // Density of the cluster subgraph
             int n = members.size();
-            int maxPossible = n * (n - 1) / 2;
+            long maxPossible = (long) n * (n - 1) / 2;
             double density = maxPossible > 0 ? (double) clusterIntra / maxPossible : 0.0;
             densities.put(cid, density);
             totalIntraDensity += density;
@@ -347,13 +347,13 @@ public class GraphClusterQualityAnalyzer {
         double intraClusterDensity = clusterCount > 0 ? totalIntraDensity / clusterCount : 0.0;
 
         // Inter-cluster density
-        int totalIntraPossible = 0;
+        long totalIntraPossible = 0;
         for (Set<String> members : clusters.values()) {
             int n = members.size();
-            totalIntraPossible += n * (n - 1) / 2;
+            totalIntraPossible += (long) n * (n - 1) / 2;
         }
-        int totalPossible = totalNodes * (totalNodes - 1) / 2;
-        int interPossible = totalPossible - totalIntraPossible;
+        long totalPossible = (long) totalNodes * (totalNodes - 1) / 2;
+        long interPossible = totalPossible - totalIntraPossible;
         double interClusterDensity = interPossible > 0
             ? (double) interEdges / interPossible : 0.0;
 

--- a/Gvisual/src/gvisual/LineGraphAnalyzer.java
+++ b/Gvisual/src/gvisual/LineGraphAnalyzer.java
@@ -226,7 +226,7 @@ public class LineGraphAnalyzer {
             classification = "1 (bipartite)";
         } else if (isOddCycle(n, m, delta)) {
             classification = "2 (odd cycle)";
-        } else if (m == n * (n - 1) / 2 && n > 0) {
+        } else if (m == (long) n * (n - 1) / 2 && n > 0) {
             classification = n % 2 == 0 ? "1 (complete, even order)" :
                     "2 (complete, odd order)";
         } else if (2 * m > delta * (n - 1)) {

--- a/Gvisual/src/gvisual/LinkPredictionAnalyzer.java
+++ b/Gvisual/src/gvisual/LinkPredictionAnalyzer.java
@@ -103,12 +103,12 @@ public class LinkPredictionAnalyzer {
         private final Method method;
         private final int totalVertices;
         private final int existingEdges;
-        private final int possibleEdges;
+        private final long possibleEdges;
         private final int candidatesEvaluated;
 
         public PredictionResult(List<PredictedLink> predictions, Method method,
                                 int totalVertices, int existingEdges,
-                                int possibleEdges, int candidatesEvaluated) {
+                                long possibleEdges, int candidatesEvaluated) {
             this.predictions = Collections.unmodifiableList(predictions);
             this.method = method;
             this.totalVertices = totalVertices;
@@ -121,7 +121,7 @@ public class LinkPredictionAnalyzer {
         public Method getMethod() { return method; }
         public int getTotalVertices() { return totalVertices; }
         public int getExistingEdges() { return existingEdges; }
-        public int getPossibleEdges() { return possibleEdges; }
+        public long getPossibleEdges() { return possibleEdges; }
         public int getCandidatesEvaluated() { return candidatesEvaluated; }
 
         /** Graph density (existing edges / possible edges). */
@@ -257,14 +257,14 @@ public class LinkPredictionAnalyzer {
     private static class PairEvaluation {
         final int n;
         final int existingEdges;
-        final int possibleEdges;
+        final long possibleEdges;
         final Map<String, Set<String>> adjacency;
         /** Ordered list of candidate pairs as [u, v] arrays. */
         final List<String[]> pairs;
         /** Common neighbors for each pair, same indexing as pairs. */
         final List<Set<String>> commonNeighbors;
 
-        PairEvaluation(int n, int existingEdges, int possibleEdges,
+        PairEvaluation(int n, int existingEdges, long possibleEdges,
                        Map<String, Set<String>> adjacency,
                        List<String[]> pairs, List<Set<String>> commonNeighbors) {
             this.n = n;
@@ -284,7 +284,7 @@ public class LinkPredictionAnalyzer {
         Collection<String> vertices = graph.getVertices();
         int n = vertices.size();
         int existingEdges = graph.getEdgeCount();
-        int possibleEdges = n * (n - 1) / 2;
+        long possibleEdges = (long) n * (n - 1) / 2;
         Map<String, Set<String>> adjacency = buildAdjacency(vertices);
 
         List<String> vertexList = new ArrayList<String>(vertices);

--- a/Gvisual/src/gvisual/MetricDimensionAnalyzer.java
+++ b/Gvisual/src/gvisual/MetricDimensionAnalyzer.java
@@ -439,7 +439,13 @@ public class MetricDimensionAnalyzer {
         ensureDistComputed();
 
         // Precompute which vertex resolves which pairs
-        int totalPairs = n * (n - 1) / 2;
+        long totalPairsL = (long) n * (n - 1) / 2;
+        if (totalPairsL > Integer.MAX_VALUE) {
+            // Graph too large for BitSet-based metric dimension
+            metricDimension = -1;
+            return metricDimension;
+        }
+        int totalPairs = (int) totalPairsL;
         // Store pairs as bit sets for fast intersection
         BitSet[] resolves = new BitSet[n];
         int pairIdx = 0;

--- a/Gvisual/src/gvisual/TournamentAnalyzer.java
+++ b/Gvisual/src/gvisual/TournamentAnalyzer.java
@@ -97,7 +97,7 @@ public class TournamentAnalyzer {
         if (n <= 1) return true;
 
         // A tournament on n vertices has exactly n*(n-1)/2 edges
-        if (graph.getEdgeCount() != n * (n - 1) / 2) return false;
+        if (graph.getEdgeCount() != (long) n * (n - 1) / 2) return false;
 
         for (int i = 0; i < n; i++) {
             for (int j = i + 1; j < n; j++) {
@@ -121,7 +121,7 @@ public class TournamentAnalyzer {
         int n = vertices.size();
         if (n <= 1) return errors;
 
-        int expected = n * (n - 1) / 2;
+        long expected = (long) n * (n - 1) / 2;
         if (graph.getEdgeCount() != expected) {
             errors.add("Expected " + expected + " edges for " + n +
                        " vertices, found " + graph.getEdgeCount());
@@ -197,14 +197,14 @@ public class TournamentAnalyzer {
         int n = sorted.size();
         if (n == 0) return true;
 
-        int cumSum = 0;
+        long cumSum = 0;
         for (int k = 1; k <= n; k++) {
             cumSum += sorted.get(k - 1);
-            int required = k * (k - 1) / 2;
+            long required = (long) k * (k - 1) / 2;
             if (cumSum < required) return false;
         }
         // Total must equal n*(n-1)/2
-        int total = n * (n - 1) / 2;
+        long total = (long) n * (n - 1) / 2;
         return cumSum == total;
     }
 

--- a/Gvisual/src/gvisual/TreewidthAnalyzer.java
+++ b/Gvisual/src/gvisual/TreewidthAnalyzer.java
@@ -764,7 +764,7 @@ public class TreewidthAnalyzer {
         }
 
         // Complete graph
-        if (edgeCount == n * (n - 1) / 2) {
+        if (edgeCount == (long) n * (n - 1) / 2) {
             return "complete graph K" + n + " (tw=" + (n - 1) + ")";
         }
 

--- a/Gvisual/src/gvisual/VertexConnectivityAnalyzer.java
+++ b/Gvisual/src/gvisual/VertexConnectivityAnalyzer.java
@@ -175,7 +175,7 @@ public class VertexConnectivityAnalyzer {
         if (!isConnected()) return 0;
 
         // Check if complete graph
-        int maxEdges = n * (n - 1) / 2;
+        long maxEdges = (long) n * (n - 1) / 2;
         if (graph.getEdgeCount() == maxEdges) return n - 1;
 
         List<String> vList = new ArrayList<>(graph.getVertices());
@@ -222,7 +222,7 @@ public class VertexConnectivityAnalyzer {
         int n = graph.getVertexCount();
         if (n <= 1 || !isConnected()) return Collections.emptySet();
 
-        int maxEdges = n * (n - 1) / 2;
+        long maxEdges = (long) n * (n - 1) / 2;
         if (graph.getEdgeCount() == maxEdges) {
             Set<String> cut = new LinkedHashSet<>(graph.getVertices());
             String keep = cut.iterator().next();


### PR DESCRIPTION
Fixes #42

## Problem
11 locations across 7 analyzers compute \
 * (n - 1) / 2\ using \int\ arithmetic, which overflows at n ≥ 46,341 vertices — producing negative values that silently corrupt density, coverage, and comparison metrics.

## Fix
Cast to \long\ before multiplication: \(long) n * (n - 1) / 2\

### Files changed (7):
- **GraphClusterQualityAnalyzer** — intra-cluster density + inter-cluster pair counts
- **LineGraphAnalyzer** — complete graph classification check
- **LinkPredictionAnalyzer** — possible edges count + \PairEvaluation\/\PredictionResult\ field types
- **MetricDimensionAnalyzer** — total pairs with early return guard for extremely large graphs
- **TournamentAnalyzer** — edge count check, cumulative sum, Landau criterion
- **TreewidthAnalyzer** — complete graph detection
- **VertexConnectivityAnalyzer** — max edges for completeness check

All 366 tests pass across all 7 affected analyzers.