### PR TITLE
fix(security): CSV formula injection in CsvReportExporter and SubgraphExtractor

### DIFF
--- a/Gvisual/src/gvisual/CsvReportExporter.java
+++ b/Gvisual/src/gvisual/CsvReportExporter.java
@@ -356,10 +356,19 @@ public class CsvReportExporter {
 
     /**
      * Escapes a value for CSV (wraps in quotes if it contains comma, quote, or newline).
+     * Also defuses formula injection: values starting with {@code =}, {@code +},
+     * {@code -}, {@code @}, {@code \t}, or {@code \r} are prefixed with a
+     * single-quote inside the quoted field so spreadsheet applications treat
+     * them as literal text rather than formulas.
      */
     private String escapeCsv(String value) {
         if (value == null) return "";
-        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+        boolean needsQuote = value.contains(",") || value.contains("\"") || value.contains("\n");
+        boolean formulaRisk = !value.isEmpty() && "=+-@\t\r".indexOf(value.charAt(0)) >= 0;
+        if (formulaRisk) {
+            return "\"'" + value.replace("\"", "\"\"") + "\"";
+        }
+        if (needsQuote) {
             return "\"" + value.replace("\"", "\"\"") + "\"";
         }
         return value;

--- a/Gvisual/src/gvisual/SubgraphExtractor.java
+++ b/Gvisual/src/gvisual/SubgraphExtractor.java
@@ -427,9 +427,20 @@ public class SubgraphExtractor {
             return sb.toString();
         }
 
+        /**
+         * Escapes a value for CSV.  In addition to the standard quoting of commas,
+         * quotes, and newlines, values that start with formula-triggering characters
+         * ({@code =}, {@code +}, {@code -}, {@code @}, tab, CR) are prefixed with a
+         * single-quote inside quotes so spreadsheet applications treat them as text.
+         */
         private static String csvEscape(String value) {
             if (value == null) return "";
-            if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            boolean needsQuote = value.contains(",") || value.contains("\"") || value.contains("\n");
+            boolean formulaRisk = !value.isEmpty() && "=+-@\t\r".indexOf(value.charAt(0)) >= 0;
+            if (formulaRisk) {
+                return "\"'" + value.replace("\"", "\"\"") + "\"";
+            }
+            if (needsQuote) {
                 return "\"" + value.replace("\"", "\"\"") + "\"";
             }
             return value;

--- a/Gvisual/test/gvisual/CsvReportExporterTest.java
+++ b/Gvisual/test/gvisual/CsvReportExporterTest.java
@@ -227,4 +227,53 @@ public class CsvReportExporterTest {
         assertTrue("Alice before Bob", idxA < idxB);
         assertTrue("Bob before Charlie", idxB < idxC);
     }
+
+    // --- CSV formula injection prevention ---
+
+    @Test
+    public void testFormulaInjectionNodeEquals() {
+        Graph<String, edge> g = new UndirectedSparseGraph<>();
+        g.addVertex("=CMD()");
+        CsvReportExporter exporter = new CsvReportExporter(g, new ArrayList<edge>());
+        String csv = exporter.exportToString();
+        assertTrue("Formula prefix defused", csv.contains("\"'=CMD()\""));
+        assertFalse("Raw formula not present", csv.contains(",=CMD(),"));
+    }
+
+    @Test
+    public void testFormulaInjectionNodePlus() {
+        Graph<String, edge> g = new UndirectedSparseGraph<>();
+        g.addVertex("+1234");
+        CsvReportExporter exporter = new CsvReportExporter(g, new ArrayList<edge>());
+        String csv = exporter.exportToString();
+        assertTrue("Plus-prefix defused", csv.contains("\"'+1234\""));
+    }
+
+    @Test
+    public void testFormulaInjectionNodeMinus() {
+        Graph<String, edge> g = new UndirectedSparseGraph<>();
+        g.addVertex("-DROP");
+        CsvReportExporter exporter = new CsvReportExporter(g, new ArrayList<edge>());
+        String csv = exporter.exportToString();
+        assertTrue("Minus-prefix defused", csv.contains("\"'-DROP\""));
+    }
+
+    @Test
+    public void testFormulaInjectionNodeAt() {
+        Graph<String, edge> g = new UndirectedSparseGraph<>();
+        g.addVertex("@SUM(A1:A10)");
+        CsvReportExporter exporter = new CsvReportExporter(g, new ArrayList<edge>());
+        String csv = exporter.exportToString();
+        assertTrue("At-prefix defused", csv.contains("\"'@SUM(A1:A10)\""));
+    }
+
+    @Test
+    public void testSafeNodeNotPrefixed() {
+        Graph<String, edge> g = new UndirectedSparseGraph<>();
+        g.addVertex("Alice");
+        CsvReportExporter exporter = new CsvReportExporter(g, new ArrayList<edge>());
+        String csv = exporter.exportToString();
+        assertTrue("Safe name present", csv.contains("Alice,"));
+        assertFalse("No spurious quoting", csv.contains("\"'Alice\""));
+    }
 }


### PR DESCRIPTION
escapeCsv()/csvEscape() didn't defuse formula-triggering characters (=, +, -, @). Node names starting with these chars could execute arbitrary commands when CSV opened in Excel/LibreOffice. Both methods hardened with single-quote prefix. 5 new tests, 16 total pass.