### PR TITLE
refactor: consolidate adjacency/neighbor cache to GraphUtils (3 analyzers)

### DIFF
--- a/Gvisual/src/gvisual/GrowthRateAnalyzer.java
+++ b/Gvisual/src/gvisual/GrowthRateAnalyzer.java
@@ -118,9 +118,10 @@ public class GrowthRateAnalyzer {
     private static double computeAvgClustering(Graph<String, edge> g) {
         if (g.getVertexCount() == 0) return 0.0;
 
+        Map<String, Set<String>> adj = GraphUtils.buildAdjacencyMap(g);
         double totalClustering = 0.0;
         for (String v : g.getVertices()) {
-            Collection<String> neighbors = g.getNeighbors(v);
+            Set<String> neighbors = adj.get(v);
             if (neighbors == null) continue;
             List<String> neighborList = new ArrayList<>(neighbors);
             int k = neighborList.size();
@@ -128,8 +129,9 @@ public class GrowthRateAnalyzer {
 
             int triangles = 0;
             for (int i = 0; i < k; i++) {
+                Set<String> ni = adj.get(neighborList.get(i));
                 for (int j = i + 1; j < k; j++) {
-                    if (g.isNeighbor(neighborList.get(i), neighborList.get(j))) {
+                    if (ni != null && ni.contains(neighborList.get(j))) {
                         triangles++;
                     }
                 }

--- a/Gvisual/src/gvisual/NodeSimilarityAnalyzer.java
+++ b/Gvisual/src/gvisual/NodeSimilarityAnalyzer.java
@@ -81,7 +81,7 @@ public class NodeSimilarityAnalyzer {
             throw new IllegalArgumentException("Graph must not be null");
         }
         this.graph = graph;
-        this.neighborCache = new HashMap<String, Set<String>>();
+        this.neighborCache = GraphUtils.buildAdjacencyMap(graph);
     }
 
     // ── Single-pair metrics ─────────────────────────────────────

--- a/Gvisual/src/gvisual/StructuralHoleAnalyzer.java
+++ b/Gvisual/src/gvisual/StructuralHoleAnalyzer.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
 public class StructuralHoleAnalyzer {
 
     private final Graph<String, edge> graph;
-    private Map<String, Set<String>> neighborCache;
+    private final Map<String, Set<String>> neighborCache;
 
     /**
      * Creates a new StructuralHoleAnalyzer for the given graph.
@@ -64,18 +64,7 @@ public class StructuralHoleAnalyzer {
             throw new IllegalArgumentException("Graph must not be null");
         }
         this.graph = graph;
-        buildNeighborCache();
-    }
-
-    private void buildNeighborCache() {
-        neighborCache = new HashMap<>();
-        for (String v : graph.getVertices()) {
-            Set<String> nbrs = new LinkedHashSet<>();
-            for (String n : graph.getNeighbors(v)) {
-                nbrs.add(n);
-            }
-            neighborCache.put(v, nbrs);
-        }
+        this.neighborCache = GraphUtils.buildAdjacencyMap(graph);
     }
 
     // ── Result classes ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
Consolidates duplicated adjacency-building code in 3 analyzers to use the shared \GraphUtils.buildAdjacencyMap()\ method.

### Changes
- **StructuralHoleAnalyzer**: Replaced private \uildNeighborCache()\ (10 lines) with single \GraphUtils.buildAdjacencyMap()\ call. Field is now \inal\.
- **NodeSimilarityAnalyzer**: Replaced lazy per-node cache population with eager \GraphUtils.buildAdjacencyMap()\ initialization.
- **GrowthRateAnalyzer**: \computeAvgClustering()\ now uses adjacency map + O(1) set lookups instead of \graph.isNeighbor()\ calls for triangle counting.

### Impact
- ~10 lines of duplicated code removed
- Consistent adjacency construction across all analyzers
- Performance improvement in GrowthRateAnalyzer triangle counting (set contains vs isNeighbor)

Part of #43