### PR TITLE
fix: use consistent endpoint access in GraphCompressor

### DIFF
--- a/Gvisual/src/gvisual/GraphCompressor.java
+++ b/Gvisual/src/gvisual/GraphCompressor.java
@@ -315,8 +315,8 @@ public class GraphCompressor {
         Map<String, SuperEdgeInfo> superEdgeInfos = new HashMap<>();
 
         for (edge e : graph.getEdges()) {
-            String v1 = graph.getEndpoints(e).getFirst();
-            String v2 = graph.getEndpoints(e).getSecond();
+            String v1 = e.getVertex1();
+            String v2 = e.getVertex2();
             String s1 = nodeToSupernode.get(v1);
             String s2 = nodeToSupernode.get(v2);
 


### PR DESCRIPTION
## What

\uildQuotientGraph\ in \GraphCompressor\ used \graph.getEndpoints(e).getFirst/Second()\ to get edge endpoints, while every other file in the project uses \.getVertex1()\ / \.getVertex2()\.

## Why

JUNG's \getEndpoints()\ returns a \Pair\ whose ordering is not guaranteed to match the edge's stored \ertex1\/\ertex2\ fields. This could cause incorrect supernode assignments during graph compression if the ordering differs.

## Fix

Switched to \.getVertex1()\ / \.getVertex2()\ for consistency with the rest of the codebase.