### PR TITLE
perf: reduce computeStress() memory from O(V²) to O(V)

### DIFF
--- a/Gvisual/src/gvisual/ForceDirectedLayout.java
+++ b/Gvisual/src/gvisual/ForceDirectedLayout.java
@@ -514,21 +514,24 @@ public class ForceDirectedLayout {
         int n = vertexList != null ? vertexList.size() : 0;
         if (n < 2) return 0;
 
-        // BFS shortest paths
-        Map<String, Map<String, Integer>> shortestPaths =
-                new HashMap<String, Map<String, Integer>>();
-        for (String v : vertexList) {
-            shortestPaths.put(v, GraphUtils.bfsDistances(graph, v));
-        }
+        // Ideal edge length: constant for this graph/layout
+        double k = Math.sqrt(width * height / n);
 
+        // Compute BFS one source at a time to reduce memory from O(V²) to O(V).
+        // The previous implementation stored all-pairs shortest paths in a
+        // Map<String, Map<String, Integer>> before iterating — for a graph
+        // with V vertices this allocates V HashMap instances with up to V
+        // entries each, plus V² Integer box objects. By computing BFS for
+        // vertex i, consuming distances to vertices j > i, and then
+        // discarding the map, we keep only one BFS result alive at a time.
         double stress = 0;
         double normalizer = 0;
-        // Ideal edge length: constant for this graph/layout, hoist out of loop
-        double k = Math.sqrt(width * height / n);
+
         for (int i = 0; i < n; i++) {
             String vi = vertexList.get(i);
             double[] pi = positions.get(vi);
-            Map<String, Integer> viPaths = shortestPaths.get(vi);
+            Map<String, Integer> viPaths = GraphUtils.bfsDistances(graph, vi);
+
             for (int j = i + 1; j < n; j++) {
                 String vj = vertexList.get(j);
                 Integer graphDist = viPaths.get(vj);


### PR DESCRIPTION
The previous implementation pre-computed all-pairs BFS shortest paths into a nested Map before iterating over pairs. For a graph with V vertices this allocates V HashMap instances with up to V entries each, plus V┬▓ boxed Integer objects ΓÇö all held in memory simultaneously.  This change computes BFS one source vertex at a time and discards the distance map after processing, keeping only one BFS result alive at any point. The algorithmic complexity is unchanged (still O(V*(V+E))) but peak heap usage drops from O(V┬▓) to O(V+E), which matters for graphs with thousands of nodes where the stress metric is most useful.